### PR TITLE
Static type-hint for the base request

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -28,7 +28,7 @@ abstract class Request
     protected array $query = [];
     protected array $data = [];
 
-    public static function build(...$args): self
+    public static function build(...$args): static
     {
         return app(static::class, $args);
     }
@@ -40,14 +40,14 @@ abstract class Request
         $this->withRequest($this->request);
     }
 
-    public function withData(array $data): self
+    public function withData(array $data): static
     {
         $this->data = array_merge($this->data, $data);
 
         return $this;
     }
 
-    public function withQuery(array $query): self
+    public function withQuery(array $query): static
     {
         $this->query = array_merge($this->query, $query);
 
@@ -59,7 +59,7 @@ abstract class Request
         $url = (string) Str::of($this->path())
             ->when(
                 !empty($this->query),
-                fn(Stringable $path): Stringable => $path->append('?', http_build_query($this->query))
+                fn (Stringable $path): Stringable => $path->append('?', http_build_query($this->query))
             );
 
         switch (mb_strtoupper($this->method)) {
@@ -95,14 +95,14 @@ abstract class Request
         return $this->request;
     }
 
-    public function setPath(string $path): self
+    public function setPath(string $path): static
     {
         $this->path = $path;
 
         return $this;
     }
 
-    public function __call(string $name, array $arguments): self
+    public function __call(string $name, array $arguments): static
     {
         if (method_exists($this->request, $name)) {
             call_user_func_array([$this->request, $name], $arguments);


### PR DESCRIPTION
Hey, 

I think the "static" type-hint would be better then "self", because with "static" you also get autocomplete for methods defined in parent classes. 

For example in one of my projects I created the following base class 
```php
<?php

namespace App\Domain\Twitch\Requests;

use Illuminate\Http\Client\PendingRequest;
use JustSteveKing\Transporter\Request;

class BaseRequest extends Request
{
    protected string $method = 'GET';
    protected string $baseUrl = 'https://api.twitch.tv/helix';

    protected array $data = [];

    protected function withRequest(PendingRequest $request): void
    {
        $token = AuthorizationRequest::build()->sendAndTransform()->accessToken;

        $request->withToken($token)
            ->withHeaders([
                'Client-ID' => "ABC",
            ]);
    }
}
```

And also a separate class for handling the authentication token
```php
<?php

namespace App\Domain\Twitch\Requests;

use Illuminate\Http\Client\PendingRequest;
use JustSteveKing\Transporter\Request;

class AuthorizationRequest extends Request
{
    protected string $method = 'POST';
    protected string $baseUrl = 'https://id.twitch.tv/';
    protected string $path = 'oauth2/token';    

    public function sendAndTransform()
    {
        $response = $this->send();


        return new AuthenticationData(
            accessToken: $response->json("access_token"),
            expiresIn: $response->json("expires_in")
        )
    }
}
```

As you can see I declared a "sendAndTransform" function , but with the "self"  type-hint I dont't get autocomplete  for this  function.

Happy to hear your thoughts on this. 