### PR TITLE
Add option for faking requests

### DIFF
--- a/tests/Stubs/PostRequest.php
+++ b/tests/Stubs/PostRequest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace JustSteveKing\Transporter\Tests\Stubs;
 
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Http\Client\PendingRequest;
 use JustSteveKing\Transporter\Request;
 
 class PostRequest extends Request
@@ -11,4 +13,16 @@ class PostRequest extends Request
     protected string $method = 'GET';
     protected string $baseUrl = 'https://jsonplaceholder.typicode.com';
     protected string $path = '/posts';
+
+    public function fakeResponse(PendingRequest $request): Response
+    {
+        return new Response(
+            body: json_encode([
+                "userId" => 100,
+                "id" => 1,
+                "title" => "sunt aut facere repellat provident occaecati excepturi optio reprehenderit",
+                "body" => "quia et suscipit\nsuscipit recusandae consequuntur expedita et cum\nreprehenderit molestiae ut ut quas totam\nnostrum rerum est autem sunt rem eveniet architecto"
+            ])
+        );
+    }
 }

--- a/tests/Stubs/TestRequest.php
+++ b/tests/Stubs/TestRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace JustSteveKing\Transporter\Tests\Stubs;
 
+use GuzzleHttp\Psr7\Response;
 use Illuminate\Http\Client\PendingRequest;
 use JustSteveKing\Transporter\Request;
 
@@ -17,8 +18,29 @@ class TestRequest extends Request
         'completed' => false,
     ];
 
+    protected ?array $fakeData = null;
+
     protected function withRequest(PendingRequest $request): void
     {
         $request->withToken('foobar');
+    }
+
+    public function withFakeData(array $data): static
+    {
+        $this->fakeData = $data;
+
+        return $this;
+    }
+
+    public function fakeResponse(): Response
+    {
+        return new Response(
+            body: json_encode($this->fakeData ?? [
+                "userId" => 1,
+                "id" => 1,
+                "title" => "delectus aut autem",
+                "completed" => false
+            ])
+        );
     }
 }

--- a/tests/TransporterTest.php
+++ b/tests/TransporterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace JustSteveKing\Transporter\Tests;
 
 use Illuminate\Http\Client\PendingRequest;
+use JustSteveKing\Transporter\Request;
 use JustSteveKing\Transporter\Tests\Stubs\PostRequest;
 use JustSteveKing\Transporter\Tests\Stubs\TestRequest;
 use JustSteveKing\Transporter\Tests\TestCase;
@@ -15,6 +16,8 @@ class TransporterTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
+
+        Request::fake();
     }
 
     /**
@@ -53,14 +56,36 @@ class TransporterTest extends TestCase
             query: [
                 'postId' => 1,
             ],
-        )->send();
+        )->withFakeData([
+            [
+                "postId"=> 1,
+                "id"=> 1,
+                "name"=> "id labore ex et quam laborum",
+                "email"=> "Eliseo@gardner.biz",
+                "body"=> "laudantium enim quasi est quidem magnam voluptate ipsam eos\ntempora quo necessitatibus\ndolor quam autem quasi\nreiciendis et nam sapiente accusantium"
+            ],
+            [
+                "postId"=> 1,
+                "id"=> 2,
+                "name"=> "quo vero reiciendis velit similique earum",
+                "email"=> "Jayne_Kuhic@sydney.com",
+                "body"=> "est natus enim nihil est dolore omnis voluptatem numquam\net omnis occaecati quod ullam at\nvoluptatem error expedita pariatur\nnihil sint nostrum voluptatem reiciendis et"
+            ],
+            [
+                "postId"=> 1,
+                "id"=> 3,
+                "name"=> "odio adipisci rerum aut animi",
+                "email"=> "Nikita@garfield.biz",
+                "body"=> "quia molestiae reprehenderit quasi aspernatur\naut expedita occaecati aliquam eveniet laudantium\nomnis quibusdam delectus saepe quia accusamus maiores nam est\ncum et ducimus et vero voluptates excepturi deleniti ratione"
+            ]
+        ])->send();
 
         $this->assertFalse(
             condition: empty($response->json()),
         );
 
         $this->assertCount(
-            expectedCount: 5,
+            expectedCount: 3,
             haystack: $response->json()
         );
 
@@ -115,5 +140,15 @@ class TransporterTest extends TestCase
                 __DIR__ . '/../vendor/orchestra/testbench-core/laravel/app/Transporter/Requests/TestRequest.php'
             )
         );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_create_a_fake_response()
+    {
+        $response = PostRequest::build()->send();
+
+        $this->assertEquals($response->json("userId"), 100);
     }
 }


### PR DESCRIPTION
I tried to add a option for faking requests. Currently there is a `fake` method on the base request class. If this gets called, all following requests will not be send. Also the request classes can now implement a `fakeResponse` method where they can define how the fake response should look like, if this method does not exist I just return an empty response. 

Happy to hear your feedback on this implementation. 