### PR TITLE
Prevent multiple `withQuery()` calls from overwriting data...

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -79,7 +79,7 @@ abstract class Request
 
     public function withQuery(array $query): static
     {
-        $this->query = array_merge($this->query, $query);
+        $this->query = array_merge_recursive($this->query, $query);
 
         return $this;
     }

--- a/src/Request.php
+++ b/src/Request.php
@@ -156,6 +156,11 @@ abstract class Request
         return $this->request;
     }
 
+    public function getQuery(): array
+    {
+        return $this->query;
+    }
+    
     public function setPath(string $path): static
     {
         $this->path = $path;

--- a/tests/Feature/RequestTest.php
+++ b/tests/Feature/RequestTest.php
@@ -125,3 +125,40 @@ it('can set the response status on fake requests', function () {
         )->send()->status()
     )->toEqual(Http::ACCEPTED);
 });
+
+it('can add query parameters recursively without overwriting', function () {
+    $query = TestRequest::fake()
+        ->withQuery(
+            query: [
+                       'postId' => 1,
+                   ],
+        )->withQuery(
+            query: [
+                        'page' => [
+                            'number' => 2,
+                        ],
+                    ],
+        )->withQuery(
+            query: [
+                        'page' => [
+                            'size' => 30,
+                        ],
+                    ],
+        )->getQuery();
+
+    expect(
+        $query
+    )->toBeArray()->toHaveCount(2);
+
+    expect(
+        $query['page']
+    )->toBeArray()->toHaveCount(2);
+
+    expect(
+        $query['page']['number']
+    )->toBe(2);
+
+    expect(
+        $query['page']['size']
+    )->toBe(30);
+});


### PR DESCRIPTION
When calling `withQuery()`, it's possible to overwrite previous entries inadvertently.

Consider implementing a request that allows for [JSON:API](https://jsonapi.org/format/#fetching-pagination) pagination using a page-based strategy. Perhaps you have the following methods:
```php
    public function pageNumber(int $pageNumber)
    {
        $this->withQuery(['page' => ['number' => $pageNumber]]);

        return $this;
    }

    public function pageSize(int $pageSize)
    {
        $this->withQuery(['page' => ['size' => $pageSize]]);

        return $this;
    }
```

If `withQuery()` uses `array_merge()`, then the `page` key is always overwritten.  So, if a user specifies the page number and then the page size, then `$this->query` will have the following value: `['page' => ['size' => ???]]`.

I believe changing `array_merge()` to `array_merge_recursive()` will resolve this.

I'm not 100% sure, but there may be reason to look into this with some of the other array-merging functionality.

Please let me know if you have any questions or concerns. 🤓