### PR TITLE
Prefer local baseUrl over global config setting...

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -55,7 +55,7 @@ abstract class Request
     public function __construct(HttpFactory $http)
     {
         $this->request = $http->baseUrl(
-            url: config('transporter.base_uri') ?? $this->baseUrl ?? '',
+            url: $this->baseUrl ?? config('transporter.base_uri') ?? '',
         );
 
         $this->withRequest(


### PR DESCRIPTION
I believe that the local baseUrl setting, if set, should be preferred over any global value that might be set via configuration file.

Before this change, if someone wants to use the config setting and some one-off local settings, then for each of the one-off instance, `setBaseUrl()` will have to be called explicitly.

After this change, someone can set the config setting and know that it will be used everywhere except for those one-off instances where it is set locally.  There is no longer any need to call `setBaseUrl()` explicitly.

Please let me know if you have any questions/concerns.