### PR TITLE
Get path without accessed-before-initialization errors

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -203,7 +203,7 @@ abstract class Request
 
     protected function path(): string
     {
-        return $this->path;
+        return $this->path ?? '';
     }
 
     public function getRequest(): PendingRequest


### PR DESCRIPTION
If descendants don't specify `$this->path`, then calling `path()` will fail with an error: `Typed property JustSteveKing\Transporter\Request::$path must not be accessed before initialization`

This is one way to resolve the problem.  Another option is to initialize the variable when it's declared:
```php
    protected string $path = '';
```

Not sure which way is best/preferable...or if there's some other even better way to go. 🤓