### PR TITLE
Fix PendingRequest methods not getting executed on concurrent requests

### DIFF
--- a/src/Concurrently.php
+++ b/src/Concurrently.php
@@ -29,11 +29,12 @@ class Concurrently
     ) { }
 
     /**
+     * @param array $args
      * @return static
      */
-    public function build(): static
+    public function build(...$args): static
     {
-        return app(static::class);
+        return app(static::class, $args);
     }
 
     /**

--- a/src/Concurrently.php
+++ b/src/Concurrently.php
@@ -55,7 +55,7 @@ class Concurrently
      */
     public function setRequests(array $requests): static
     {
-        $this->requests = $requests;
+        $this->requests = [];
         foreach ($requests as $request) {
             if ($request->getAs() !== null) {
                 $this->requests[$request->getAs()] = $request;

--- a/tests/Feature/RequestTest.php
+++ b/tests/Feature/RequestTest.php
@@ -119,6 +119,20 @@ it('can run concurrent requests', function () {
     expect($responses)->toBeArray()->toHaveCount(3);
 });
 
+it('does not run concurrent requests twice', function () {
+    $http = app(\Illuminate\Http\Client\Factory::class);
+    $http->fake();
+
+    $requests = [
+        TestRequest::build(http: $http),
+        TestRequest::build(http: $http),
+    ];
+
+    Concurrently::build(http: $http)->setRequests($requests)->run();
+
+    $http->assertSentCount(2);
+});
+
 it('can actually run concurrency', function () {
     $requests = [
         TestRequest::fake()->withQuery(


### PR DESCRIPTION
When you use methods that get forwarded to the PendingRequest (things like withToken), they will only get executed on the PendingRequest created on the HttpFactory, not on the PendingRequest generated by the pool (different PendingRequest). Same goes for the withRequest method.

I ran into this when thinking about introducing middleware into the Request class, and wanting to support concurrent requests in that case as well.

My approach in this pull request:

- Don’t create PendingRequest immediately, only when using getRequest(), send() and buildForConcurrent().
- Store methods that should be forwarded to the PendingRequest into an array.
- Create ensureRequest() method which creates the PendingRequest from a factory or a pool and runs the stored methods.

This might be a bit of a controversial approach, but please look it over and let me know your thoughts.

I also came across problems with the setRequests() method on Concurrently, which adds the requests to the array twice. That is fixed in a second commit.