### PR TITLE
Add support for Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/contracts": "^8.37",
+        "illuminate/contracts": "^8.37|^9.0",
         "juststeveking/http-status-code": "^2.0",
         "juststeveking/uri-builder": "^1.1",
         "spatie/laravel-package-tools": "^1.4.3"


### PR DESCRIPTION
Based on my testing in my application, it would appear at a first glance that just a version bump in composer should be enough.