### PR TITLE
Fixed setting baseUrl on request when using concurrently with as

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace JustSteveKing\Transporter;
 
-use GuzzleHttp\Promise\Promise;
 use Illuminate\Http\Client\Pool;
 use JustSteveKing\StatusCode\Http;
 use OutOfBoundsException;
@@ -299,7 +298,7 @@ abstract class Request
     }
 
     /**
-     * @param Pool $pool
+     * @param Pool|null $pool
      */
     private function ensureRequest(null|Pool $pool = null): void
     {
@@ -310,9 +309,11 @@ abstract class Request
                 );
             } else {
                 $this->request = match ($this->as === null) {
-                    false => $pool->as(
-                        key: $this->as
-                    ),
+                    false => $pool
+                        ->as(key: $this->as)
+                        ->baseUrl(
+                            url: $this->baseUrl ?? config('transporter.base_uri') ?? '',
+                        ),
                     true => $pool->baseUrl(
                         url: $this->baseUrl ?? config('transporter.base_uri') ?? '',
                     )


### PR DESCRIPTION
```php
Concurrently::build()->setRequests([
       WalletFetchRequest::build()->withWalletId(1000004)->as('a'),
       WalletFetchRequest::build()->withWalletId(1000004)->as('b'),
])->run();
```
When using the concurrently like above sample i'm getting this error

```
Transporter\{closure}(): Argument #1 ($response) must be of type Illuminate\Http\Client\Response, GuzzleHttp\Exception\ConnectException given

cURL error 6: Could not resolve host: general (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for general/wallets/1000004
```

so it fixed it in this pull request
