### PR TITLE
feat: add `$throws` to requests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,8 @@
     "require-dev": {
         "brianium/paratest": "^6.2",
         "guzzlehttp/guzzle": "^7.3",
-        "nunomaduro/collision": "^5.3",
-        "orchestra/testbench": "^6.15",
+        "nunomaduro/collision": "^6.3.1",
+        "orchestra/testbench": "^7.14.1",
         "pestphp/pest": "^1.20",
         "phpstan/phpstan": "^1.1",
         "phpunit/phpunit": "^9.3",

--- a/tests/Feature/RequestTest.php
+++ b/tests/Feature/RequestTest.php
@@ -1,13 +1,16 @@
 <?php
 
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Artisan;
-use JustSteveKing\StatusCode\Http;
+use Illuminate\Support\Facades\Http;
+use JustSteveKing\StatusCode\Http as Status;
 use JustSteveKing\Transporter\Facades\Concurrently;
 use JustSteveKing\Transporter\Commands\TransporterCommand;
 use JustSteveKing\Transporter\Tests\Stubs\BaseUriRequest;
 use JustSteveKing\Transporter\Tests\Stubs\PostRequest;
 use JustSteveKing\Transporter\Tests\Stubs\TestRequest;
+use JustSteveKing\Transporter\Tests\Stubs\ThrowingRequest;
 
 it('can create a pending request', function () {
     expect(TestRequest::fake()->getRequest())
@@ -283,7 +286,7 @@ it('can add data to the request', function () {
         PostRequest::fake()->withData(
             data: $data
         )->send()->status(),
-    )->toEqual(Http::OK);
+    )->toEqual(Status::OK);
 });
 
 it('can create a new api request using the command', function () {
@@ -353,20 +356,20 @@ it('can set a base uri using lockOn alias', function () {
     );
 
     expect(
-       $request->getBaseUrl()
+        $request->getBaseUrl()
     )->toEqual('https://example.com');
 });
 
 it('can set the response status on fake requests', function () {
     expect(
         TestRequest::fake()->send()->status()
-    )->toEqual(Http::OK);
+    )->toEqual(Status::OK);
 
     expect(
         TestRequest::fake(
-            status: Http::ACCEPTED
+            status: Status::ACCEPTED
         )->send()->status()
-    )->toEqual(Http::ACCEPTED);
+    )->toEqual(Status::ACCEPTED);
 });
 
 it('can add query parameters recursively without overwriting', function () {
@@ -462,3 +465,8 @@ it('applies withRequest and pending request calls concurrently', function () {
             $request->hasHeader('X-Test', '2');
     });
 });
+
+it('throws if `throws` is set to `true`', function () {
+    Http::fake(fn () => Http::response(status: Status::UNAUTHORIZED));
+    ThrowingRequest::build()->send();
+})->throws(RequestException::class);

--- a/tests/Stubs/ThrowingRequest.php
+++ b/tests/Stubs/ThrowingRequest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JustSteveKing\Transporter\Tests\Stubs;
+
+use JustSteveKing\Transporter\Request;
+
+class ThrowingRequest extends Request
+{
+    protected string $method = 'GET';
+    protected string $baseUrl = 'https://jsonplaceholder.typicode.com';
+    protected string $path = '/todos';
+    protected bool $throws = true;
+}


### PR DESCRIPTION
This PR adds a convenient `$throws` property to `JustSteveKing\Transporter\Request` to avoid having to call `->throw` after each `->send` call. 

Currently, I have the following in all my base `Request` classes:

```php
public function send(): Response
{
    return parent::send()->throw();
}
```

After this PR, I may simply override the `$throws` property and set it to `true`.

I also updated the development dependencies, otherwise I couldn't use `Http::fake` in the tests.