### PR TITLE
feat: add basic cache support

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -246,7 +246,10 @@ abstract class Request
     {
         $cacheKey ??= $this->cacheKey ?? Str::of(static::class)
             ->classBasename()
+            ->kebab()
             ->append($this->path)
+            ->kebab()
+            ->when($this->query)->append(':' . http_build_query($this->query))
             ->kebab();
 
         return cache()->remember(

--- a/tests/Feature/RequestTest.php
+++ b/tests/Feature/RequestTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Carbon\Carbon;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Artisan;
 use JustSteveKing\StatusCode\Http;
@@ -353,7 +354,7 @@ it('can set a base uri using lockOn alias', function () {
     );
 
     expect(
-       $request->getBaseUrl()
+        $request->getBaseUrl()
     )->toEqual('https://example.com');
 });
 
@@ -461,4 +462,21 @@ it('applies withRequest and pending request calls concurrently', function () {
             $request->hasHeader('Authorization', 'Bearer foobar') &&
             $request->hasHeader('X-Test', '2');
     });
+});
+
+it('remembers a response', function () {
+    TestRequest::fake()->withFakeData([
+        'foo' => 'bar'
+    ])->remember(
+        ttl: now()->addMinute(),
+        cacheKey: 'test-request'
+    );
+
+    expect(cache()->get('test-request')->json())->toBe([
+        'foo' => 'bar'
+    ]);
+
+    Carbon::setTestNow(now()->addMinutes(2));
+
+    expect(cache()->has('test-request'))->toBeFalse();
 });


### PR DESCRIPTION
This PR adds basic support for remembering request responses. I often need to implement it myself when dealing with 3rd party APIs, and I thought it would be nice to have this built in.

```php
SomeRequest::build()->remember(now()->addMinute());
```

This could be further improved by adding configurable properties to the `Request` class, but I wanted to keep it simple, at least for now. I also wanted to inject the cache manager to `Request`, but I think this could be a breaking change, so I opted for using service locator via the `cache()` helper instead.